### PR TITLE
Add protobuf support

### DIFF
--- a/Sources/SwagGenKit/CodeFormatter.swift
+++ b/Sources/SwagGenKit/CodeFormatter.swift
@@ -296,6 +296,14 @@ public class CodeFormatter {
                 formProperties = formSchema.properties.map(getPropertyContext)
                 context["isUpload"] = formSchema.properties.contains { $0.schema.isFile }
             }
+            if let schema = requestBody.value.content.protobufSchema {
+                let name = requestBody.name ?? "Body"
+                if let schemaContext = getInlineSchemaContext(schema, name: name) {
+                    requestSchemas.append(schemaContext)
+                }
+                context["body"] = getRequestBodyContext(requestBody)
+                context["bodyProperties"] = schema.properties.map(getPropertyContext)
+            }
         }
         context["requestSchemas"] = requestSchemas
         context["formProperties"] = formProperties

--- a/Sources/Swagger/Content.swift
+++ b/Sources/Swagger/Content.swift
@@ -9,6 +9,7 @@ public struct Content {
         case form = "application/x-www-form-urlencoded"
         case xml = "application/xml"
         case multipartForm = "multipart/form-data"
+        case protobuf = "application/protobuf"
         case text = "text/plain"
     }
 
@@ -30,6 +31,10 @@ public struct Content {
 
     public var xmlSchema: Schema? {
         return getMediaItem(.xml)?.schema
+    }
+
+    public var protobufSchema: Schema? {
+        return getMediaItem(.protobuf)?.schema
     }
 }
 

--- a/Templates/Swift/template.yml
+++ b/Templates/Swift/template.yml
@@ -17,7 +17,7 @@ options:
   propertyNames: {} # override property names
   anyType: Any # override Any in generated models
   typeAliases:
-    ID: UUID
+    ID: String
     DateTime: Date
     File: Data
   dependencies:


### PR DESCRIPTION
Added Protobuf support in request and response body. The Protobuf files are received as `File` (typealias for Data) and sent as `File`. So the (de-)serialization is to be done by the client.