### PR TITLE
Read header information from api

### DIFF
--- a/Sources/SwagGenKit/SwiftFormatter.swift
+++ b/Sources/SwagGenKit/SwiftFormatter.swift
@@ -204,6 +204,14 @@ public class SwiftFormatter: CodeFormatter {
             let generatedOperationId = operation.method.rawValue.lowercased() + pathName.upperCamelCased()
             context["fileName"] = escapeType("\(requestPrefix)\(generatedOperationId.upperCamelCased())")
         }
+        if let requirements = context["securityRequirements"] as? [[String: Any?]],
+           requirements.contains(where: {
+            guard let value = $0["name"] as? String else { return false }
+            return value == "OAuth2" || value == "OIDC"
+           }) {
+            context["authorizationRequired"] = true
+        }
+
         return context
     }
 

--- a/Templates/Swift/Common/APIRequest.swift
+++ b/Templates/Swift/Common/APIRequest.swift
@@ -104,6 +104,8 @@ extension {{ options.name }}Request {
             urlRequest.httpBody = formParams.query?.data(using: .utf8)
         }
 
+        urlRequest.setValue(contentType, forHTTPHeaderField: "Accept")
+
         if let encodeBody = encodeBody {
             urlRequest.httpBody = try encodeBody(encoder)
             urlRequest.setValue(contentType, forHTTPHeaderField: "Content-Type")

--- a/Templates/Swift/Common/Request.swift
+++ b/Templates/Swift/Common/Request.swift
@@ -140,8 +140,25 @@ extension {{ options.name }}{% if tag %}.{{ options.tagPrefix }}{{ tag|upperCame
                 headers["{{ param.value }}"] = {% if param.type == "String" %}options.{{ param.encodedValue }}{% else %}String(describing: options.{{ param.encodedValue }}){% endif %}
                 {% endif %}
                 {% endfor %}
+                {% if authorizationRequired %}
+                if let token = API.accessToken {
+                    headers["Authorization"] = "Bearer \(token)"
+                }
+                {% endif %}
+
                 return headers
             }
+            {% else %}
+            {% if authorizationRequired %}
+
+            override var headerParameters: [String: String] {
+                var headers: [String: String] = [:]
+                if let token = API.oAuthToken {
+                    headers["Authorization"] = "Bearer \(token)"
+                }
+                return headers
+            }
+            {% endif %}
             {% endif %}
         }
 


### PR DESCRIPTION
- Automatically add `Authorization` header if there security requirements
- Set `Accept` header for every request