### PR TITLE
Fix generation of accept headers

### DIFF
--- a/Sources/SwagGenKit/CodeFormatter.swift
+++ b/Sources/SwagGenKit/CodeFormatter.swift
@@ -420,8 +420,6 @@ public class CodeFormatter {
         context["schema"] = response.response.value.schema.flatMap(getSchemaContext)
         context["description"] = response.response.value.description.description
         context["type"] = response.response.value.schema.flatMap { getSchemaType(name: response.name, schema: $0) }
-        context["acceptHeaders"] = response.response.value.content?.mediaItems.keys.map{$0}
-        context["acceptHeaderEnums"] = response.response.value.content?.mediaItems.keys.map{$0.replacingOccurrences(of: "/", with: "_").replacingOccurrences(of: ".", with: "_").replacingOccurrences(of: "+", with: "_").uppercased()}
 
         return context
     }

--- a/Sources/SwagGenKit/KotlinFormatter.swift
+++ b/Sources/SwagGenKit/KotlinFormatter.swift
@@ -198,6 +198,8 @@ public class KotlinFormatter: CodeFormatter {
         
         let type = context["type"] as? String ?? ""
         context["isAnyType"] = type.contains("Any")
+        context["acceptHeaders"] = response.response.value.content?.mediaItems.keys.map{$0}
+        context["acceptHeaderEnums"] = response.response.value.content?.mediaItems.keys.map{$0.replacingOccurrences(of: "/", with: "_").replacingOccurrences(of: ".", with: "_").replacingOccurrences(of: "+", with: "_").uppercased()}
         
         return context
     }

--- a/Sources/SwagGenKit/SwiftFormatter.swift
+++ b/Sources/SwagGenKit/SwiftFormatter.swift
@@ -321,6 +321,11 @@ public class SwiftFormatter: CodeFormatter {
         var context = super.getResponseContext(response)
         let type = context["type"] as? String ?? ""
         context["isAnyType"] = type.contains("Any")
+
+        let mediaTypes = response.response.value.content?.mediaItems.keys
+        context["acceptHeaders"] = mediaTypes?.compactMap { $0 }
+        context["acceptHeadersEnumCases"] = mediaTypes?.compactMap { $0.replacingOccurrences(of: "/", with: "_").replacingOccurrences(of: ".", with: "_").replacingOccurrences(of: "+", with: "_").replacingOccurrences(of: "-", with: "_") }
+
         return context
     }
 


### PR DESCRIPTION
- Create AcceptHeader enum if response defines more than one content type
- AcceptHeader needs to be set by the client